### PR TITLE
feat: rescript version update

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
   "devDependencies": {
     "@rescript/react": "^0.10.3",
     "prettier": "^2.5.1",
-    "rescript-react-native": "^0.64.3 || ^0.65.0 || ^0.66.0",
-    "rescript": "^9.1.4"
+    "rescript": "^10.0.1",
+    "rescript-react-native": "^0.64.3 || ^0.65.0 || ^0.66.0"
   },
   "prettier": {
     "trailingComma": "all"

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,7 +17,7 @@ prettier@^2.5.1:
   resolved "https://registry.yarnpkg.com/rescript-react-native/-/rescript-react-native-0.66.1.tgz#50a477dae1413c74dead9e32b87e81e98a419418"
   integrity sha512-i404Nv9jsNrBpQOcNmP09VZRRyE4JPcxLywTFuNzmnF0gCX94ZvrMvVI2zhrNQ83V8E32ctrPnusE+mCxe+1eg==
 
-rescript@^9.1.4:
-  version "9.1.4"
-  resolved "https://registry.yarnpkg.com/rescript/-/rescript-9.1.4.tgz#1eb126f98d6c16942c0bf0df67c050198e580515"
-  integrity sha512-aXANK4IqecJzdnDpJUsU6pxMViCR5ogAxzuqS0mOr8TloMnzAjJFu63fjD6LCkWrKAhlMkFFzQvVQYaAaVkFXw==
+rescript@^10.0.1:
+  version "10.0.1"
+  resolved "https://registry.yarnpkg.com/rescript/-/rescript-10.0.1.tgz#5b2da8a8bcfb994bed1eb24820bf10cfb9d8c440"
+  integrity sha512-XwO1GPDtoEU4H03xQE5bp0/qtSVR6YLaJRPxWKrfFgKc+LI36ODOCie7o9UJfgzQdoMYkkZyiTGZ4N9OQEaiUw==


### PR DESCRIPTION
This updates the ReScript version to 10.1

No breaking changes were detected and, apparently, everything works fine.

Related to: https://github.com/reck753/rescript-reanimated/issues/4